### PR TITLE
deep linking with universal link format for 🌈

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -205,13 +205,11 @@ class App extends React.Component<any, any> {
   public createDeepLink = async () => {
     const { walletConnector } = this.state;
     if (walletConnector) {
-      const uri = walletConnector.uri;
-
-      // const deepLink: string = uri.replace("wc:", "rainbow:");
-
-      const deepLink: string = `rainbow://${uri}&redirectUrl=${encodeURIComponent(
+      const uri: string = encodeURIComponent(walletConnector.uri);
+      const redirectUrl: string = encodeURIComponent(
         window.location.href
-      )}`;
+      );
+      const deepLink: string = `https://rainbow.me/wc?uri=${uri}&redirectUrl=${redirectUrl}`;
 
       await this.setState({ deepLink });
     }


### PR DESCRIPTION
Redirect URL will require a "walletconnect=true" query param (also url encoded in payload)