### PR TITLE
fixing to use npm instead of yarn and adding npm install

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,24 @@
 # WalletConnect Example Dapp
 
+## Install
+
+```bash
+npm install
+```
 ## Develop
 
 ```bash
-yarn start
+npm start
 ```
 
 ## Test
 
 ```bash
-yarn test
+npm test
 ```
 
 ## Build
 
 ```bash
-yarn build
+npm build
 ```


### PR DESCRIPTION
The instruction was wrong as I was having failed to compile with `Type of property 'propTypes' circularly references itself` error and there's package-lock.json with no yarn.lock

![image](https://user-images.githubusercontent.com/148800/84587266-f6448300-ae60-11ea-9c53-7541f62a193c.png)
