### PR TITLE
fix: chainId mismatch for eth_signTypedData

### DIFF
--- a/src/helpers/eip712.ts
+++ b/src/helpers/eip712.ts
@@ -27,7 +27,7 @@ const example = {
   domain: {
     name: "GSN Relayed Transaction",
     version: "1",
-    chainId: 42,
+    chainId: 1,
     verifyingContract: "0x6453D37248Ab2C16eBd1A8f782a2CBC65860E60B",
   },
   primaryType: "RelayRequest",


### PR DESCRIPTION
The [EIP-712](https://eips.ethereum.org/EIPS/eip-712) says `The user-agent should refuse signing if it does not match the currently active chain.`

The Dapp connects with chainId 1, but send a request with chainId 42