### PR TITLE
Use mainnet chainid in eip712 example

### DIFF
--- a/src/helpers/eip712.ts
+++ b/src/helpers/eip712.ts
@@ -27,7 +27,7 @@ const example = {
   domain: {
     name: "GSN Relayed Transaction",
     version: "1",
-    chainId: 42,
+    chainId: 1,
     verifyingContract: "0x6453D37248Ab2C16eBd1A8f782a2CBC65860E60B",
   },
   primaryType: "RelayRequest",


### PR DESCRIPTION
Unable to test this flow using Metamask mobile or any wallet that verifies `domain.chainId`